### PR TITLE
feat: Inferred Prop Typings

### DIFF
--- a/src/lib/render/index.ts
+++ b/src/lib/render/index.ts
@@ -1,4 +1,5 @@
 import { render as svelteRender } from 'svelte/server';
+import type { Component, ComponentProps, SvelteComponent } from 'svelte';
 import { parse, serialize, type DefaultTreeAdapterTypes } from 'parse5';
 import postcss from 'postcss';
 import { walk } from './utils/html/walk.js';
@@ -57,6 +58,28 @@ export type RenderOptions = {
 	props?: Omit<Record<string, any>, '$$slots' | '$$events'> | undefined;
 	context?: Map<any, any>;
 	idPrefix?: string;
+};
+
+export type RenderableComponent = SvelteComponent<any> | Component<any>;
+
+export type RenderComponentInput<Comp extends RenderableComponent> = Comp extends SvelteComponent<any>
+	? Component<Comp>
+	: Comp;
+
+export type RenderComponentProps<Comp extends RenderableComponent> = [ComponentProps<Comp>] extends [never]
+	? Record<string, any>
+	: ComponentProps<Comp>;
+
+export type TypedRenderOptions<Comp extends RenderableComponent> = Omit<RenderOptions, 'props'> & {
+	props?: Omit<RenderComponentProps<Comp>, '$$slots' | '$$events'> & Record<string, any>;
+};
+
+export type RenderFunction = {
+	<Comp extends RenderableComponent>(
+		component: RenderComponentInput<Comp>,
+		options?: TypedRenderOptions<Comp>
+	): Promise<string>;
+	(component: any, options?: RenderOptions | undefined): Promise<string>;
 };
 
 /**
@@ -140,7 +163,7 @@ export default class Renderer {
 	 * });
 	 * ```
 	 */
-	render = async (component: any, options?: RenderOptions | undefined) => {
+	render: RenderFunction = async (component: any, options?: RenderOptions | undefined) => {
 		const { body } = svelteRender(component, options);
 
 		let ast = parse(body);


### PR DESCRIPTION
Added proper typings to the render method that allows for proper intellisense when rendering an email.

All tests pass and also tested locally. No runtime changes, only typings.

Given the following component `VercelInviteUser` and the following props

```typescript
	interface Props {
		username?: string;
		userImage?: string;
		invitedByUsername?: string;
		invitedByEmail?: string;
		teamName?: string;
		teamImage?: string;
		inviteLink?: string;
		inviteFromIp?: string;
		inviteFromLocation?: string;
	}
```

<img width="864" height="315" alt="image" src="https://github.com/user-attachments/assets/b708470b-ba6c-4e5b-84ca-a6b452bf5469" />

You now get proper Intellisense moving forward making it easier to catch mistakes before runtime.