### PR TITLE
fix(render): Greptile feedback on PR #83 render typings

### DIFF
--- a/src/lib/render/index.ts
+++ b/src/lib/render/index.ts
@@ -62,21 +62,17 @@ export type RenderOptions = {
 
 export type RenderableComponent = SvelteComponent<any> | Component<any>;
 
-export type RenderComponentInput<Comp extends RenderableComponent> = Comp extends SvelteComponent<any>
-	? Component<Comp>
-	: Comp;
-
 export type RenderComponentProps<Comp extends RenderableComponent> = [ComponentProps<Comp>] extends [never]
 	? Record<string, any>
 	: ComponentProps<Comp>;
 
 export type TypedRenderOptions<Comp extends RenderableComponent> = Omit<RenderOptions, 'props'> & {
-	props?: Omit<RenderComponentProps<Comp>, '$$slots' | '$$events'> & Record<string, any>;
+	props?: Omit<RenderComponentProps<Comp>, '$$slots' | '$$events'>;
 };
 
 export type RenderFunction = {
 	<Comp extends RenderableComponent>(
-		component: RenderComponentInput<Comp>,
+		component: Comp,
 		options?: TypedRenderOptions<Comp>
 	): Promise<string>;
 	(component: any, options?: RenderOptions | undefined): Promise<string>;

--- a/src/lib/render/index.ts
+++ b/src/lib/render/index.ts
@@ -62,6 +62,9 @@ export type RenderOptions = {
 
 export type RenderableComponent = SvelteComponent<any> | Component<any>;
 
+/** Component constructor or function accepted by the typed `render` overload. */
+export type RenderComponentInput<Comp extends RenderableComponent> = Comp;
+
 export type RenderComponentProps<Comp extends RenderableComponent> = [ComponentProps<Comp>] extends [never]
 	? Record<string, any>
 	: ComponentProps<Comp>;
@@ -72,7 +75,7 @@ export type TypedRenderOptions<Comp extends RenderableComponent> = Omit<RenderOp
 
 export type RenderFunction = {
 	<Comp extends RenderableComponent>(
-		component: Comp,
+		component: RenderComponentInput<Comp>,
 		options?: TypedRenderOptions<Comp>
 	): Promise<string>;
 	(component: any, options?: RenderOptions | undefined): Promise<string>;

--- a/src/lib/render/index.ts
+++ b/src/lib/render/index.ts
@@ -1,4 +1,5 @@
 import { render as svelteRender } from 'svelte/server';
+import type { Component, ComponentProps, SvelteComponent } from 'svelte';
 import { parse, serialize, type DefaultTreeAdapterTypes } from 'parse5';
 import postcss from 'postcss';
 import { walk } from './utils/html/walk.js';
@@ -57,6 +58,28 @@ export type RenderOptions = {
 	props?: Omit<Record<string, any>, '$$slots' | '$$events'> | undefined;
 	context?: Map<any, any>;
 	idPrefix?: string;
+};
+
+export type RenderableComponent = SvelteComponent<any> | Component<any>;
+
+export type RenderComponentInput<Comp extends RenderableComponent> = Comp extends SvelteComponent<any>
+	? Component<Comp>
+	: Comp;
+
+export type RenderComponentProps<Comp extends RenderableComponent> = [ComponentProps<Comp>] extends [never]
+	? Record<string, any>
+	: ComponentProps<Comp>;
+
+export type TypedRenderOptions<Comp extends RenderableComponent> = Omit<RenderOptions, 'props'> & {
+	props?: Omit<RenderComponentProps<Comp>, '$$slots' | '$$events'> & Record<string, any>;
+};
+
+export type RenderFunction = {
+	<Comp extends RenderableComponent>(
+		component: RenderComponentInput<Comp>,
+		options?: TypedRenderOptions<Comp>
+	): Promise<string>;
+	(component: any, options?: RenderOptions | undefined): Promise<string>;
 };
 
 /**
@@ -140,7 +163,7 @@ export default class Renderer {
 	 * });
 	 * ```
 	 */
-	render = async (component: any, options?: RenderOptions | undefined) => {
+	render: RenderFunction = async (component: any, options?: RenderOptions | undefined) => {
 		const { body } = svelteRender(component, options);
 
 		let ast = parse(body);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the [Greptile review on PR #83](https://github.com/Konixy/better-svelte-email/pull/83#issuecomment-4110364651):

1. **Prop value types** — Removed `& Record<string, any>` from `TypedRenderOptions['props']` so `ComponentProps<Comp>` is not widened to `any` for every prop value.
2. **`RenderComponentInput`** — Replaced the incorrect `Comp extends SvelteComponent<any> ? Component<Comp> : Comp` conditional with `RenderComponentInput<Comp> = Comp`, keeping the exported name from PR #83 while matching real usage (callers pass the component constructor/function).

This branch includes the PR #83 changes (merged via `refs/pull/83/head`) plus the typing fixes above.

## Verification

- `bun run check` — 0 errors (existing CSS warnings unchanged)
- `bun run test` — all tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59123e0e-a005-4f21-9824-d227b0c6ee29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59123e0e-a005-4f21-9824-d227b0c6ee29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

