### PR TITLE
docs: fix Greptile feedback for email preview beta guide (PR #94)

### DIFF
--- a/apps/docs/src/routes/docs/email-preview-beta/+page.md
+++ b/apps/docs/src/routes/docs/email-preview-beta/+page.md
@@ -1,16 +1,18 @@
-**Beta.** `@better-svelte-email/cli` and related tooling are in beta; defaults and flags may change.
+<aside class="docs-beta-notice">
+<p><strong>Beta.</strong> <code>@better-svelte-email/cli</code> and related tooling are in beta; defaults and flags may change.</p>
+</aside>
 
 # Email dev server (beta)
 
-For **v2**, the recommended workflow is the `**@better-svelte-email/cli`** command-line tool. It starts a dedicated **email preview server** in any project folder: file watching, live reload, HTML/source views, and rendering through `[@better-svelte-email/server](./render-beta)`. You do **not\*\* need a SvelteKit preview route.
+For **v2**, the recommended workflow is the **`@better-svelte-email/cli`** command-line tool. It starts a dedicated **email preview server** in any project folder: file watching, live reload, HTML/source views, and rendering through [**@better-svelte-email/server**](./render-beta). You do **not** need a SvelteKit preview route.
 
-Right now, `**dev`\*\* is the only command the CLI provides; other subcommands may be added later.
+Right now, **`dev`** is the only command the CLI provides; other subcommands may be added later.
 
 > **Try it live!** The hosted docs use the same preview UI—open [/preview](/preview) to explore sample templates.
 
 ## `@better-svelte-email/preview` (deprecated)
 
-The `**@better-svelte-email/preview`** package (`EmailPreview`, `createEmail`, `sendEmail`, SvelteKit `+page.server.ts` wiring) is **deprecated**. It remains published for **backward compatibility** with apps that already embed the inline preview. **New projects should use `@better-svelte-email/cli`\*\* instead.
+The **`@better-svelte-email/preview`** package (`EmailPreview`, `createEmail`, `sendEmail`, SvelteKit `+page.server.ts` wiring) is **deprecated**. It remains published for **backward compatibility** with apps that already embed the inline preview. **New projects should use `@better-svelte-email/cli`** instead.
 
 For the classic SvelteKit-integrated flow (v1-style, stable package), see [Email Preview](./email-preview).
 
@@ -24,7 +26,7 @@ Pick one (or combine dev dependency + `npx` for CI).
 npm install -D @better-svelte-email/cli
 ```
 
-The package exposes the `**bse**` binary in `node_modules/.bin`. Use npm scripts (see [Run the dev server](#run-the-dev-server)) or:
+The package exposes the **`bse`** binary in `node_modules/.bin`. Use npm scripts (see [Run the dev server](#run-the-dev-server)) or:
 
 ```bash
 npx @better-svelte-email/cli dev
@@ -45,7 +47,7 @@ npm install -g @better-svelte-email/cli
 bse dev
 ```
 
-Your email templates should import primitives from `[@better-svelte-email/components](./components-beta)`. The CLI uses `**@better-svelte-email/server**` internally to render those components.
+Your email templates should import primitives from [`@better-svelte-email/components`](./components-beta). The CLI uses **`@better-svelte-email/server`** internally to render those components.
 
 ## Run the dev server
 
@@ -60,7 +62,7 @@ npx @better-svelte-email/cli dev
 **After `npm install -D @better-svelte-email/cli`:**
 
 ```bash
-npx @better-svelte-email/cli dev
+bse dev
 ```
 
 **After a global install:**
@@ -69,7 +71,7 @@ npx @better-svelte-email/cli dev
 bse dev
 ```
 
-This watches `**src/lib/emails**` by default and serves the preview UI (bundled **preview-server** build) on **port 3000**, with JSON APIs under `/api/`\* on the same origin.
+This watches **`src/lib/emails`** by default and serves the preview UI (bundled **preview-server** build) on **port 3000**, with JSON APIs under `/api/*` on the same origin.
 
 ### `package.json` script
 
@@ -132,9 +134,9 @@ For working on the preview app itself (e.g. in this monorepo), the API and UI ru
 
 The dev server exposes a small JSON API (also used by the bundled preview):
 
-- `**GET /api/emails**` — lists template files under the configured emails directory.
-- `**GET /api/source?file=…**` — returns source for a template path.
-- `**POST /api/render**` — body `{ "file": "…", "props": { … }, "includeSource"?: boolean }` — returns rendered HTML (and optional source).
+- **`GET /api/emails`** — lists template files under the configured emails directory.
+- **`GET /api/source?file=…`** — returns source for a template path.
+- **`POST /api/render`** — body `{ "file": "…", "props": { … }, "includeSource"?: boolean }` — returns rendered HTML (and optional source).
 
 There is **no built-in “send test email”** endpoint in the CLI server; use your provider (Resend, etc.) from your own app or scripts if you need outbound mail.
 
@@ -148,7 +150,7 @@ There is **no built-in “send test email”** endpoint in the CLI server; use y
 
 ### Styles look wrong
 
-Pass `**-c`\*\* to the same CSS entry you use for Tailwind v4 / variables in the app, or ensure `src/app.css` / `src/routes/layout.css` exists so the CLI can pick it up automatically.
+Pass **`-c`** to the same CSS entry you use for Tailwind v4 / variables in the app, or ensure `src/app.css` / `src/routes/layout.css` exists so the CLI can pick it up automatically.
 
 ### Port already in use
 
@@ -160,4 +162,4 @@ With `--preview-dev`, also set `--preview-port` to a free port different from `-
 
 ## Legacy package reference
 
-If you must keep `**@better-svelte-email/preview**` in a SvelteKit app, the API surface is described in the [v1 Email Preview](./email-preview#api-reference) doc (`createEmail`, `sendEmail`, `emailList`, etc.). Prefer migrating to `**npx @better-svelte-email/cli dev**` (or a local/global `**bse**`) when you can.
+If you must keep **`@better-svelte-email/preview`** in a SvelteKit app, the API surface is described in the [v1 Email Preview](./email-preview#api-reference) doc (`createEmail`, `sendEmail`, `emailList`, etc.). Prefer migrating to **`npx @better-svelte-email/cli dev`** (or a local/global **`bse`**) when you can.

--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
     },
     "packages/better-svelte-email": {
       "name": "better-svelte-email",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "@better-svelte-email/components": "workspace:*",
         "@better-svelte-email/preview": "workspace:*",
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "@better-svelte-email/cli",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "bin": {
         "bse": "./dist/index.cjs",
       },
@@ -97,7 +97,7 @@
     },
     "packages/components": {
       "name": "@better-svelte-email/components",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "@better-svelte-email/server": "workspace:*",
       },
@@ -111,7 +111,7 @@
     },
     "packages/preview": {
       "name": "@better-svelte-email/preview",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "@better-svelte-email/server": "workspace:*",
         "prettier": "^3.8.1",
@@ -127,7 +127,7 @@
     },
     "packages/preview-server": {
       "name": "@better-svelte-email/preview-server",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "@lucide/svelte": "^1.0.1",
         "@sveltejs/adapter-node": "^5.5.4",
@@ -150,7 +150,7 @@
     },
     "packages/server": {
       "name": "@better-svelte-email/server",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "dependencies": {
         "html-to-text": "^9.0.5",
         "parse5": "^8.0.0",

--- a/packages/better-svelte-email/README.md
+++ b/packages/better-svelte-email/README.md
@@ -3,13 +3,13 @@
 > [!WARNING]
 > **Compatibility package:** this npm name exists mainly for a **single-install** workflow. It **re-exports** `[@better-svelte-email/server](../server)` and `[@better-svelte-email/components](../components)`, and depends on `[@better-svelte-email/preview](../preview)` so versions stay aligned. It does **not** add its own runtime beyond those re-exports.
 >
-> **Maintenance:** active development targets the scoped packages below. This meta-package **may receive less attention over time** and is not guaranteed to track every new export from the underlying packages—prefer depending on `**@better-svelte-email/*`\*\* directly when you want the clearest upgrade path.
+> **Maintenance:** active development targets the scoped packages below. This meta-package **may receive less attention over time** and is not guaranteed to track every new export from the underlying packages—prefer depending on **`@better-svelte-email/*`** directly when you want the clearest upgrade path.
 
 ---
 
 Published meta-package for **Better Svelte Email**: render Svelte 5 email templates to HTML with Tailwind CSS inlined for email clients, plus optional preview and send helpers.
 
-The **published main entry** re-exports **components** plus `**Renderer`**, `**toPlainText**`, and related types from the server package. Import preview and SvelteKit helpers from `**@better-svelte-email/preview\*\*` directly. For maximal control you can depend on the scoped packages only and skip this meta-package.
+The **published main entry** re-exports **components** plus **`Renderer`**, **`toPlainText`**, and related types from the server package. Import preview and SvelteKit helpers from **`@better-svelte-email/preview`** directly. For maximal control you can depend on the scoped packages only and skip this meta-package.
 
 ## Documentation
 
@@ -25,14 +25,14 @@ Minimum **Svelte** version: **5.14.3**.
 
 ## What you get
 
-From `**better-svelte-email`\*\* (main export):
+From **`better-svelte-email`** (main export):
 
-- `**Renderer**` and `**toPlainText**` — server-side HTML (+ optional plain text) from `.svelte` templates, with Tailwind inlined for email clients
+- **`Renderer`** and **`toPlainText`** — server-side HTML (+ optional plain text) from `.svelte` templates, with Tailwind inlined for email clients
 - **Email layout components** — `Html`, `Body`, `Container`, `Section`, `Text`, `Button`, … (same as `[@better-svelte-email/components](../components)`)
 
-From `**@better-svelte-email/preview`\*\* (installed as a dependency; import this module name):
+From **`@better-svelte-email/preview`** (installed as a dependency; import this module name):
 
-- `**EmailPreview**`, `**createEmail**`, `**sendEmail**`, `**emailList**`, … for local preview and test sends in SvelteKit
+- **`EmailPreview`**, **`createEmail`**, **`sendEmail`**, **`emailList`**, … for local preview and test sends in SvelteKit
 
 ## Monorepo
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -36,7 +36,7 @@ This package depends on `[@better-svelte-email/server](../server)` for shared re
 
 Individual `.svelte` files can be imported via the `./ComponentName.svelte` export pattern (see `package.json` `exports`).
 
-`**@better-svelte-email/components/utils**` — shared utilities subpath (see `exports`).
+**`@better-svelte-email/components/utils`** — shared utilities subpath (see `exports`).
 
 Most users install the umbrella package `[better-svelte-email](../better-svelte-email)` instead, which re-exports these components.
 

--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -1,7 +1,7 @@
 # @better-svelte-email/preview
 
 > [!WARNING]
-> This package is still in **beta**; APIs and behavior may change before a stable release.
+> **Deprecated for new projects.** This package remains published for **compatibility** with existing SvelteKit apps that already wire `EmailPreview`, `createEmail`, and `sendEmail`. **New projects** should use **`@better-svelte-email/cli`** for a standalone email dev server instead of adding preview routes to the app. APIs and behavior may still change before a stable release.
 
 **Preview and test-send** utilities for Better Svelte Email inside **SvelteKit**: UI component, form actions to render templates on demand, and optional **Resend** integration for sending test messages.
 
@@ -17,9 +17,9 @@ npm i @better-svelte-email/preview
 
 ## Main exports
 
-- `**EmailPreview`\*\* — Svelte component for browsing and previewing templates (also available as `@better-svelte-email/preview/EmailPreview.svelte`)
-- `**createEmail**` — returns SvelteKit actions that render a selected template to HTML (and source) using `Renderer`
-- `**sendEmail**` — actions that render and send via **Resend** (API key server-side) or a custom send function
+- **`EmailPreview`** — Svelte component for browsing and previewing templates (also available as `@better-svelte-email/preview/EmailPreview.svelte`)
+- **`createEmail`** — returns SvelteKit actions that render a selected template to HTML (and source) using `Renderer`
+- **`sendEmail`** — actions that render and send via **Resend** (API key server-side) or a custom send function
 - **Filesystem helpers** — `emailList`, `getEmailComponent`, `getFiles`, etc. for wiring a local emails directory
 
 Typical pattern: spread `createEmail({ renderer })` and `sendEmail({ resendApiKey, renderer })` into `+page.server.ts` `actions`, and mount `EmailPreview` on a dev-only route. See JSDoc in `src/index.ts` and the [docs](https://better-svelte-email.konixy.dev/docs).

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -19,10 +19,10 @@ npm i @better-svelte-email/server
 
 The main entry exposes:
 
-- `**Renderer`** — configure Tailwind (`tailwindConfig`), optional injected `**customCSS`** (e.g. theme variables), then `**render(component, options)**` to produce HTML
-- `**toPlainText**` — derive a plain-text version from rendered HTML
+- **`Renderer`** — configure Tailwind (`tailwindConfig`), optional injected **`customCSS`** (e.g. theme variables), then **`render(component, options)`** to produce HTML
+- **`toPlainText`** — derive a plain-text version from rendered HTML
 - **Types** — `TailwindConfig`, `RendererOptions`, `RenderOptions`, `AST`, etc.
-- `**pixelBasedPreset`\*\* — Tailwind-related helper for pixel-oriented email styling
+- **`pixelBasedPreset`** — Tailwind-related helper for pixel-oriented email styling
 
 See JSDoc in the source and the [project documentation](https://better-svelte-email.konixy.dev/docs) for examples.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This follow-up addresses the Greptile review on PR #94.

Changes:

- **Email dev server (beta) doc** (`apps/docs/src/routes/docs/email-preview-beta/+page.md`): Open with the same `aside.docs-beta-notice` pattern as other beta pages so the amber callout styling applies. Fix malformed `` `**...`** `` markdown (use `` **`...`** `` or proper links). After a local `npm install -D @better-svelte-email/cli`, the run example now uses `bse dev` instead of duplicating the `npx` form. Clean up API route bullets, the `/api/*` wording, and the styles troubleshooting line.

- **`@better-svelte-email/preview` README**: Lead with deprecation guidance for new projects (prefer `@better-svelte-email/cli`) and fix the same bold+code markdown issue on the export list.

- **Scoped package READMEs** (`better-svelte-email`, `server`, `components`): Fix remaining `` `**...`** `` / stray backtick patterns so GitHub renders bold code correctly.

- **`bun.lock`**: Refreshed after `bun install` (workspace package versions aligned).

Validation: `bun run test` passed. `bun run check` fails in this environment on pre-existing docs TypeScript resolution for `@better-svelte-email/components` imports (unrelated to these markdown edits).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5082fbf7-3b24-4c66-9167-e8578f91ba3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5082fbf7-3b24-4c66-9167-e8578f91ba3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

